### PR TITLE
I updated the converter for FluxBB 1.5

### DIFF
--- a/ConnectixBoards/_config.php
+++ b/ConnectixBoards/_config.php
@@ -162,8 +162,3 @@ function convert_posts($message)
 	$errors = array();
 	return preparse_bbcode(preg_replace($pattern, $replace, $message), $errors);
 }
-
-function decode_ip($int_ip){
-	$hexipbang = explode('.', chunk_split($int_ip, 2, '.'));
-	return hexdec($hexipbang[0]). '.' . hexdec($hexipbang[1]) . '.' . hexdec($hexipbang[2]) . '.' . hexdec($hexipbang[3]);
-}

--- a/ConnectixBoards/groups.php
+++ b/ConnectixBoards/groups.php
@@ -8,13 +8,30 @@ while($ob = $fdb->fetch_assoc($result))
 	
 	if (trim($ob['gr_name']) == '')
 		$ob['gr_name'] = 'Group';
-	
+
 	// Dataarray
 	$todb = array(
 		'g_id'				=>	$ob['gr_id'], 
 		'g_title'			=>	$ob['gr_name'],	
 		'g_user_title'		=> 	$ob['gr_name'],
 	);
+
+	// For FluxBB 1.5 compatibility
+	if(substr(FORUM_VERSION,0,3) == '1.5')
+	{
+		if ($ob['gr_cond'] >= 0)
+		{
+			$g = $fdb->query('SELECT gr_id, MIN(gr_cond) AS gr_next FROM '.$fdb->prefix.'groups WHERE gr_cond > '.$ob['gr_cond']) or error('Unable to fetch next group', __FILE__, __LINE__, $fdb->error());
+			$group = $fdb->fetch_assoc($g);
+			$todb['g_promote_min_posts'] = $ob['gr_cond'];
+			$todb['g_promote_next_group'] = $group['gr_next'];
+		}
+		else
+		{
+			$todb['g_promote_min_posts'] = 0;
+			$todb['g_promote_next_group'] = 0;
+		}
+	}
 
 	// Save data
 	insertdata('groups', $todb, __FILE__, __LINE__);

--- a/end.php
+++ b/end.php
@@ -30,7 +30,8 @@
 	generate_bans_cache();
 	generate_quickjump_cache();
 	generate_config_cache();
-	generate_ranks_cache();
+	if (function_exists('generate_ranks_cache')) // fluxbb 1.5 has dropped ranks table
+		generate_ranks_cache();
 	if (function_exists('generate_users_info_cache')) // fluxbb > 1.4.4
 		generate_users_info_cache();
 	if (function_exists('generate_colorize_groups_cache')) // colorize groups mod


### PR DESCRIPTION
Hello,

Today (or yesterday, depending on your timezone) I downloaded FluxBB 1.5-beta in order to test it and update the migration tool.
Now I just finished updating the migration tool, so the tool itself and the Connectix Boards converter are now compatible with the upcoming FluxBB 1.5.

As FluxBB 1.5 dropped the ranks table, I updates the tool's end.php file, so the ranks cache generation will be done only if the function exists.  In the CB converter, I added the minimum postcount and the next group within the data to insert. I also removed the decode_ip function in _config.php, for it is an artifact from phpBB2 converter.

All those changes are now on the repo, so I invite you to update your repo in order to be up-to-date.

Thanks in advance.

MissGeek
